### PR TITLE
Display was not working on T4.1 - plus option to update changed range

### DIFF
--- a/src/HX8357_t3n.h
+++ b/src/HX8357_t3n.h
@@ -578,6 +578,8 @@ class HX8357_t3n : public Print
     uint16_t	*_pfbtft;						// Optional Frame buffer 
     uint8_t		_use_fbtft;						// Are we in frame buffer mode?
     uint16_t	*_we_allocated_buffer;			// We allocated the buffer; 
+	int16_t  	_changed_min_x, _changed_max_x, _changed_min_y, _changed_max_y;
+	bool 		_updateChangedAreasOnly = false;	// current default off, 
     // Add DMA support. 
 #if defined(__IMXRT1052__) || defined(__IMXRT1062__)  // Teensy 4.x
     uint16_t	*_pfbtft_async;					// pointer to async buffer at start of async operation...
@@ -890,6 +892,40 @@ class HX8357_t3n : public Print
 	}
 
 #endif
+	#ifdef ENABLE_HX8357_FRAMEBUFFER
+	void clearChangedRange() {
+		_changed_min_x = 0x7fff;
+		_changed_max_x = -1;
+		_changed_min_x = 0x7fff;
+		_changed_max_y = -1;
+  	}
+
+	void updateChangedRange(int16_t x, int16_t y, int16_t w, int16_t h)
+	  	__attribute__((always_inline)) {
+	 	if (x < _changed_min_x) _changed_min_x = x;	
+	 	if (y < _changed_min_y) _changed_min_y = y;	
+	 	x += w - 1;
+	 	y += h - 1;
+	 	if (x > _changed_max_x) _changed_max_x = x;	
+	 	if (y > _changed_max_y) _changed_max_y = y;	
+	}
+
+	// could combine with above, but avoids the +-...
+	void updateChangedRange(int16_t x, int16_t y)
+	  	__attribute__((always_inline)) {
+	 	if (x < _changed_min_x) _changed_min_x = x;	
+	 	if (y < _changed_min_y) _changed_min_y = y;	
+	 	if (x > _changed_max_x) _changed_max_x = x;	
+	 	if (y > _changed_max_y) _changed_max_y = y;	
+	}
+	#endif
+
+	void updateChangedAreasOnly(bool updateChangedOnly) {
+#ifdef ENABLE_HX8357_FRAMEBUFFER
+		_updateChangedAreasOnly = updateChangedOnly;
+#endif
+	}
+
 
 
 	void HLine(int16_t x, int16_t y, int16_t w, uint16_t color)
@@ -973,6 +1009,7 @@ class HX8357_t3n : public Print
 
 		#ifdef ENABLE_HX8357_FRAMEBUFFER
 	  	if (_use_fbtft) {
+			updateChangedRange(x, y);		// update the range of the screen that has been changed;
 	  		_pfbtft[y*_width + x] = color;
 	  		return;
 	  	}


### PR DESCRIPTION
While trying to integreate code I had in ILI9341_t3n, that keeps track of a dirty area, while using frame buffer and alllow to only update that region,

I found that display would not startup on my T4.1...
Found our Init code was a lot different than Adafruit, especially with timing.

Also setrotation different?  for MADCTL

@mjs513 - Not sure how this worked before?  I know I tested earlier, but for some reason not working for me now... You should see if this works OK on your machine as well... 